### PR TITLE
Exclude Resources/config from CS fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
+    ->notPath('Resources/config/')
 ;
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
## Summary
- Exclude `Resources/config/` directory from PHP CS Fixer to avoid formatting Symfony service configuration files

## Test plan
- [x] `composer cs-check` passes with no violations
- [x] Verify `Resources/config/` files are untouched by fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)