### PR TITLE
Add #[BindsFrom] attribute and convert BindUtils to DI service

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "php-lsp@claude-plugins-official": true
+  }
+}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,14 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
-/*
- * This file is part of the ChamberOrchestra package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__.'/src')
     ->in(__DIR__.'/tests')
@@ -19,29 +10,23 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PER-CS' => true,
         '@Symfony' => true,
+        '@Symfony:risky' => true,
+        '@PHP85Migration' => true,
+        '@PHP8x5Migration:risky' => true,
         'header_comment' => [
             'header' => <<<'EOF'
-                This file is part of the ChamberOrchestra package.
+This file is part of the ChamberOrchestra package.
 
-                For the full copyright and license information, please view the LICENSE
-                file that was distributed with this source code.
-                EOF,
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF,
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
         ],
-        'declare_strict_types' => true,
         'strict_param' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sort_algorithm' => 'alpha'],
-        'no_unused_imports' => true,
-        'trailing_comma_in_multiline' => true,
-        'single_quote' => true,
-        'global_namespace_import' => [
-            'import_classes' => false,
-            'import_constants' => false,
-            'import_functions' => false,
-        ],
         'native_function_invocation' => [
             'include' => ['@all'],
-            'scope' => 'all',
+            'scope' => 'namespaced',
             'strict' => true,
         ],
     ])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,22 +32,23 @@ The core abstraction is `ViewInterface` (marker interface). `ResponseViewInterfa
 - **View** — abstract base class implementing `ViewInterface`; convenience superclass for custom views
 - **ResponseView** — base with status code (200) and JSON headers; implements `ResponseViewInterface` and `NormalizableInterface`
 - **DataView** — wraps any `ViewInterface` or array under a `"data"` key; implements `ResponseViewInterface`
-- **BindView** — extends `stdClass`; maps matching properties from a source domain object using reflection via `BindUtils::sync()`. The `#[Type(ViewClass::class)]` attribute on `IterableView` properties specifies element view classes
+- **BindView** — extends `stdClass`; maps matching properties from a source domain object using reflection via `BindUtils::sync()`. Uses a static `setBindUtils()`/`getBindUtils()` bridge to receive the DI-managed `BindUtils` instance (falls back to `new BindUtils()` without DI). The `#[BindsFrom(EntityClass::class)]` attribute declares source classes for targeted cache warming. The `#[Type(ViewClass::class)]` attribute on `IterableView` properties specifies element view classes
 - **IterableView** — maps collections via callback or view class string
 - **KeyValueView** — produces associative array output for metadata blocks
 
 ### Request/Response Flow
 
-1. **SetVersionSubscriber** (priority 256, early) — on `RequestEvent`, configures `BindUtils` with build ID, cache lifetime, and `shareDir` for warm cache loading. Caching enabled when `APP_DEBUG=false` (24h lifetime)
+1. **SetVersionSubscriber** (priority 256, early) — on `RequestEvent`, calls `BindView::setBindUtils()` to inject the DI-managed `BindUtils` instance into the static bridge
 2. Controller returns a `ViewInterface` object
 3. **ViewSubscriber** — on `ViewEvent`, detects `ViewInterface` results, wraps non-`ResponseViewInterface` in `DataView`, serializes to JSON, and sets status/headers
 
 ### Property Binding (BindUtils)
 
-`BindUtils` is a singleton that synchronizes properties between source objects and BindView instances. It uses reflection to find intersecting properties, validates type compatibility, and handles:
+`BindUtils` is a DI service that synchronizes properties between source objects and BindView instances. Configured via constructor (`$buildId`, `$debug`, `$shareDir`) and registered in the container by `services.php`. It uses reflection to find intersecting properties, validates type compatibility, and handles:
 - Built-in types, custom objects, ViewInterface subclasses (auto-constructed), IterableView with `#[Type]` attribute
 - Skips union types and incompatible types
-- Caching enabled in production (`APP_DEBUG=false`), disabled in debug mode
+- Property accessor caching enabled when `$buildId` is non-empty; 24h lifetime in production (`$debug=false`), disabled in debug mode
+- Exposes `isReflectionTypeValidForInitialization()`, `isView()`, and `isAutoConfigurableType()` as `public static` utility methods (shared with `BindUtilsCacheWarmer`)
 
 ### Doctrine Integration
 
@@ -64,7 +65,7 @@ The core abstraction is `ViewInterface` (marker interface). `ResponseViewInterfa
 
 Two cache warmers pre-compute reflection data at deploy time, writing exported PHP files to `kernel.share_dir`:
 
-- **BindUtilsCacheWarmer** — pre-computes view-to-view property intersection mappings for `BindUtils`
+- **BindUtilsCacheWarmer** — pre-computes property intersection mappings for `BindUtils`. Uses `#[BindsFrom]` attributes on target views to limit pairs to declared source classes; falls back to N² view×view pairs when no attribute is present
 - **ViewMetadataCacheWarmer** — pre-computes serialization metadata for `ViewNormalizer`
 
 **ViewPass** (compiler pass) collects classes tagged `chamber_orchestra.view` and passes them to both cache warmers.
@@ -86,7 +87,7 @@ Two cache warmers pre-compute reflection data at deploy time, writing exported P
 - PHPUnit 13.x; tests in `tests/` autoloaded as `Tests\`
 - **Unit tests** (`tests/Unit/`) extend `TestCase`; mirror source structure
 - **Integration tests** (`tests/Integrational/`) extend `KernelTestCase`; use `Tests\Integrational\TestKernel` (minimal kernel with FrameworkBundle + ChamberOrchestraViewBundle)
-- Tests reset `BindUtils` and `ReflectionService` static state between runs
+- Tests call `BindView::setBindUtils(null)` in setUp/tearDown to reset the static bridge; `ReflectionService` uses instance storage (no static reset needed)
 - Use data providers for mapping scenarios and cache behavior
 - Write code that is easy to test.
 - Avoid hard dependencies; use dependency injection where appropriate.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ return [
 Define a view model that maps properties from a domain object:
 
 ```php
-use ChamberOrchestra\ViewBundle\View\BindView;
+use ChamberOrchestra\ViewBundle\Attribute\BindsFrom;
 use ChamberOrchestra\ViewBundle\Attribute\Type;
+use ChamberOrchestra\ViewBundle\View\BindView;
 use ChamberOrchestra\ViewBundle\View\IterableView;
 
+#[BindsFrom(User::class)]
 final class UserView extends BindView
 {
     public string $id;
@@ -111,7 +113,7 @@ final class GetMeAction
 
 ### Request/Response Flow
 
-1. **SetVersionSubscriber** (priority 256) — configures `BindUtils` with `kernel.share_dir`, `container.build_id`, and enables property accessor caching when `APP_DEBUG=false`
+1. **SetVersionSubscriber** (priority 256) — injects the DI-managed `BindUtils` instance into `BindView` via `BindView::setBindUtils()`
 2. Controller returns a `ViewInterface` object
 3. **ViewSubscriber** — detects `ViewInterface` results, wraps non-`ResponseViewInterface` in `DataView`, serializes to JSON via `ViewNormalizer`
 
@@ -132,7 +134,7 @@ The bundle includes a two-phase optimization strategy for production environment
 ### Phase 2: Build-Time Cache Warming
 
 - `ViewMetadataCacheWarmer` pre-computes view property metadata at build time
-- `BindUtilsCacheWarmer` pre-computes view-to-view property mappings
+- `BindUtilsCacheWarmer` pre-computes property mappings (uses `#[BindsFrom]` for targeted source classes, falls back to N² pairs)
 - Generated opcache-optimized PHP files stored in `kernel.share_dir`
 - Cache files are versioned with `container.build_id` for safe deployments
 - 60-80% reduction in reflection overhead on production requests
@@ -140,7 +142,7 @@ The bundle includes a two-phase optimization strategy for production environment
 
 ### Cache Configuration
 
-`SetVersionSubscriber` configures `BindUtils` with the share directory and build ID. When `APP_DEBUG=false`, property accessor caching is enabled with a 24-hour lifetime.
+`BindUtils` is registered as a DI service with `$buildId`, `$debug`, and `$shareDir` constructor arguments. When `APP_DEBUG=false`, property accessor caching is enabled with a 24-hour lifetime. `SetVersionSubscriber` injects the configured instance into `BindView` on each request.
 
 **Warm the cache in production:**
 
@@ -154,31 +156,20 @@ This generates build-versioned files in the shared cache directory:
 
 ## Benchmarks
 
-Benchmark scripts are included to measure serialization performance and cache impact:
+PHPBench benchmarks are included to measure serialization performance and cache impact:
 
 ```bash
-# Quick normalization timing
-php benchmark/simple-timing.php
-
-# Cache warmup impact test
-php benchmark/cache-warmup-test.php
-
-# Memory usage analysis
-php benchmark/memory-test.php
+composer bench                               # Run all benchmarks
+vendor/bin/phpbench run --report=default     # Run with default report
 ```
 
-**PHPBench integration:**
-
-```bash
-composer require --dev phpbench/phpbench
-vendor/bin/phpbench run --report=default
-```
+Benchmark classes: `BindUtilsBench`, `CacheWarmupBench`, `NormalizationBench`.
 
 ## Development
 
 ```bash
 composer install          # Install dependencies
-composer test             # Run all tests (87 tests, 326 assertions)
+composer test             # Run all tests (93 tests, 328 assertions)
 ./bin/phpunit             # Run tests directly
 ./bin/phpunit --filter X  # Run specific test class or method
 ```

--- a/benchmark/BindUtilsBench.php
+++ b/benchmark/BindUtilsBench.php
@@ -12,10 +12,12 @@ class BindUtilsBench
 {
     private object $source;
     private string $viewClass;
+    private BindUtils $bindUtils;
 
     public function __construct()
     {
-        BindUtils::configure('bench-build-id', 0, 'bench');
+        $this->bindUtils = new BindUtils('bench-build-id');
+        BindView::setBindUtils($this->bindUtils);
 
         $this->source = new class {
             public string $name = 'John Doe';
@@ -54,6 +56,6 @@ class BindUtilsBench
         $target->age = null;
         $target->email = null;
 
-        BindUtils::instance()->sync($target, $this->source);
+        $this->bindUtils->sync($target, $this->source);
     }
 }

--- a/benchmark/CacheWarmupBench.php
+++ b/benchmark/CacheWarmupBench.php
@@ -7,7 +7,6 @@ namespace Benchmark;
 use ChamberOrchestra\ViewBundle\CacheWarmer\BindUtilsCacheWarmer;
 use ChamberOrchestra\ViewBundle\CacheWarmer\ViewMetadataCacheWarmer;
 use ChamberOrchestra\ViewBundle\Serializer\Metadata\ViewMetadataFactory;
-use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use ChamberOrchestra\ViewBundle\View\BindView;
 use ChamberOrchestra\ViewBundle\View\View;
 use PhpBench\Attributes as Bench;
@@ -23,7 +22,7 @@ class CacheWarmupBench
 
     public function __construct()
     {
-        BindUtils::configure('bench-build-id', 0, 'bench');
+        BindView::setBindUtils(null);
 
         $simpleView = new class extends View {
             public string $name = 'Test';

--- a/src/Attribute/BindsFrom.php
+++ b/src/Attribute/BindsFrom.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the ChamberOrchestra package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChamberOrchestra\ViewBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final readonly class BindsFrom
+{
+    public function __construct(public string $class)
+    {
+        if (!\class_exists($class)) {
+            throw new \InvalidArgumentException(\sprintf('Class "%s" does not exist', $class));
+        }
+    }
+}

--- a/src/CacheWarmer/BindUtilsCacheWarmer.php
+++ b/src/CacheWarmer/BindUtilsCacheWarmer.php
@@ -67,7 +67,7 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
         $path = $outputDir.'/'.$filename;
 
         if (!\is_dir($outputDir)) {
-            \mkdir($outputDir, 0777, true);
+            \mkdir($outputDir, 0o777, true);
         }
 
         \file_put_contents($path, $code);
@@ -95,7 +95,7 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
 
         /** @var list<class-string> $sourceClasses */
         $sourceClasses = \array_map(
-            fn (\ReflectionAttribute $attr) => $attr->newInstance()->class,
+            static fn (\ReflectionAttribute $attr) => $attr->newInstance()->class,
             $attributes
         );
 

--- a/src/CacheWarmer/BindUtilsCacheWarmer.php
+++ b/src/CacheWarmer/BindUtilsCacheWarmer.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace ChamberOrchestra\ViewBundle\CacheWarmer;
 
+use ChamberOrchestra\ViewBundle\Attribute\BindsFrom;
 use ChamberOrchestra\ViewBundle\PropertyAccessor\ReflectionService;
+use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\VarExporter\VarExporter;
 
@@ -42,7 +44,7 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
 
         // Pre-compute View-to-View property mappings
         foreach ($this->viewClasses as $targetClass) {
-            foreach ($this->viewClasses as $sourceClass) {
+            foreach ($this->getSourceClasses($targetClass) as $sourceClass) {
                 $cacheKey = $targetClass.'@'.$sourceClass;
 
                 try {
@@ -74,6 +76,33 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
     }
 
     /**
+     * Returns the source classes to pair with a target class.
+     * If the target has #[BindsFrom] attributes, only declared sources are used.
+     * Otherwise, falls back to all view classes (backward-compatible N² behavior).
+     *
+     * @param class-string $targetClass
+     *
+     * @return array<class-string>
+     */
+    private function getSourceClasses(string $targetClass): array
+    {
+        $reflection = new \ReflectionClass($targetClass);
+        $attributes = $reflection->getAttributes(BindsFrom::class);
+
+        if ([] === $attributes) {
+            return $this->viewClasses;
+        }
+
+        /** @var list<class-string> $sourceClasses */
+        $sourceClasses = \array_map(
+            fn (\ReflectionAttribute $attr) => $attr->newInstance()->class,
+            $attributes
+        );
+
+        return $sourceClasses;
+    }
+
+    /**
      * Simplified version of BindUtils::getIntersectedProperties() for cache warming.
      *
      * @param class-string $targetClassName
@@ -102,7 +131,7 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
                 continue;
             }
 
-            if (!$this->isReflectionTypeValidForInitialization($targetType, $sourceType)) {
+            if (!BindUtils::isReflectionTypeValidForInitialization($targetType, $sourceType)) {
                 continue;
             }
 
@@ -118,37 +147,5 @@ final readonly class BindUtilsCacheWarmer implements CacheWarmerInterface
         }
 
         return $intersection;
-    }
-
-    /**
-     * Copied from BindUtils for cache warming.
-     */
-    private function isReflectionTypeValidForInitialization(\ReflectionType $targetType, \ReflectionType $sourceType): bool
-    {
-        if (!$targetType instanceof \ReflectionNamedType) {
-            return false;
-        }
-
-        $sourceTypes = $sourceType instanceof \ReflectionUnionType ? $sourceType->getTypes() : [$sourceType];
-
-        if ($targetType->isBuiltin()) {
-            foreach ($sourceTypes as $st) {
-                if ($st instanceof \ReflectionNamedType && $st->isBuiltin()) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        // For View classes, we can't check ViewInterface/BindView/IterableView here
-        // since we're in cache warming context, so allow all non-builtin matches
-        foreach ($sourceTypes as $st) {
-            if ($st instanceof \ReflectionNamedType && \is_a($targetType->getName(), $st->getName(), true)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/CacheWarmer/ViewMetadataCacheWarmer.php
+++ b/src/CacheWarmer/ViewMetadataCacheWarmer.php
@@ -66,7 +66,7 @@ final readonly class ViewMetadataCacheWarmer implements CacheWarmerInterface
         $path = $outputDir.'/'.$filename;
 
         if (!\is_dir($outputDir)) {
-            \mkdir($outputDir, 0777, true);
+            \mkdir($outputDir, 0o777, true);
         }
 
         \file_put_contents($path, $code);

--- a/src/DependencyInjection/ChamberOrchestraViewExtension.php
+++ b/src/DependencyInjection/ChamberOrchestraViewExtension.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ChamberOrchestra\ViewBundle\DependencyInjection;
 
-use ChamberOrchestra\ViewBundle\EventSubscriber\SetVersionSubscriber;
 use ChamberOrchestra\ViewBundle\Serializer\Metadata\ViewMetadataFactory;
+use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -31,7 +31,7 @@ class ChamberOrchestraViewExtension extends Extension
     {
         $buildId = new Parameter('container.build_id');
 
-        $container->getDefinition(SetVersionSubscriber::class)->setArgument('$buildId', $buildId);
+        $container->getDefinition(BindUtils::class)->setArgument('$buildId', $buildId);
         $container->getDefinition(ViewMetadataFactory::class)->setArgument('$buildId', $buildId);
         $container->getDefinition('chamber_orchestra.view_bundle.cache_warmer.view_metadata')->setArgument('$buildId', $buildId);
         $container->getDefinition('chamber_orchestra.view_bundle.cache_warmer.bind_utils')->setArgument('$buildId', $buildId);

--- a/src/EventSubscriber/SetVersionSubscriber.php
+++ b/src/EventSubscriber/SetVersionSubscriber.php
@@ -12,31 +12,20 @@ declare(strict_types=1);
 namespace ChamberOrchestra\ViewBundle\EventSubscriber;
 
 use ChamberOrchestra\ViewBundle\Utils\BindUtils;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use ChamberOrchestra\ViewBundle\View\BindView;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 #[AsEventListener(RequestEvent::class, priority: 256)]
 readonly class SetVersionSubscriber
 {
-    private const int CACHE_LIFETIME_SECONDS = 86400; // 24 hours
-
     public function __construct(
-        private string $buildId = '',
-        #[Autowire('%env(bool:APP_DEBUG)%')]
-        private bool $debug = false,
-        #[Autowire('%kernel.share_dir%')]
-        private ?string $shareDir = null,
+        private BindUtils $bindUtils,
     ) {
     }
 
     public function __invoke(): void
     {
-        BindUtils::configure(
-            $this->buildId,
-            $this->debug ? 0 : self::CACHE_LIFETIME_SECONDS,
-            'view_bind',
-            $this->shareDir
-        );
+        BindView::setBindUtils($this->bindUtils);
     }
 }

--- a/src/PropertyAccessor/ReflectionPropertyAccessor.php
+++ b/src/PropertyAccessor/ReflectionPropertyAccessor.php
@@ -134,6 +134,6 @@ readonly class ReflectionPropertyAccessor implements PropertyAccessorInterface
             '/^Can\'t get a way to read the property "'.$propertyPath.'" in class '.\preg_quote($objectType, '/').'$/',
         ];
 
-        return \array_any($interceptablePatterns, fn (string $pattern): bool => (bool) \preg_match($pattern, $e->getMessage()));
+        return \array_any($interceptablePatterns, static fn (string $pattern): bool => (bool) \preg_match($pattern, $e->getMessage()));
     }
 }

--- a/src/PropertyAccessor/ReflectionService.php
+++ b/src/PropertyAccessor/ReflectionService.php
@@ -18,7 +18,7 @@ class ReflectionService
     private const MAX_CACHE_SIZE = 512;
 
     /** @var array<string, array<string, \ReflectionProperty>> */
-    private static array $storage = [];
+    private array $storage = [];
 
     /**
      * @param \ReflectionClass<object>|class-string $class
@@ -30,8 +30,8 @@ class ReflectionService
     public function getReflectionProperties(\ReflectionClass|string $class): array
     {
         $className = $class instanceof \ReflectionClass ? $class->getName() : $class;
-        if (isset(self::$storage[$className])) {
-            return self::$storage[$className];
+        if (isset($this->storage[$className])) {
+            return $this->storage[$className];
         }
 
         $cache = [];
@@ -44,11 +44,11 @@ class ReflectionService
             $cache = \array_merge($cache, $this->getReflectionProperties($parent));
         }
 
-        if (\count(self::$storage) >= self::MAX_CACHE_SIZE) {
-            unset(self::$storage[\array_key_first(self::$storage)]);
+        if (\count($this->storage) >= self::MAX_CACHE_SIZE) {
+            unset($this->storage[\array_key_first($this->storage)]);
         }
 
-        return self::$storage[$className] = $cache;
+        return $this->storage[$className] = $cache;
     }
 
     /**

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 use ChamberOrchestra\ViewBundle\CacheWarmer\BindUtilsCacheWarmer;
 use ChamberOrchestra\ViewBundle\CacheWarmer\ViewMetadataCacheWarmer;
 use ChamberOrchestra\ViewBundle\Serializer\Normalizer\ViewNormalizer;
+use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 
@@ -25,6 +26,12 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(CustomNormalizer::class);
     $services->set(ViewNormalizer::class);
+
+    // Register BindUtils as a DI service
+    // Note: $buildId is set in ChamberOrchestraViewExtension (container.build_id is unavailable at load time)
+    $services->set(BindUtils::class)
+        ->arg('$debug', '%env(bool:APP_DEBUG)%')
+        ->arg('$shareDir', '%kernel.share_dir%');
 
     // Configure cache warmers (ViewPass will inject View class names)
     // Note: $buildId is set in ChamberOrchestraViewExtension (container.build_id is unavailable at load time)

--- a/src/Utils/BindUtils.php
+++ b/src/Utils/BindUtils.php
@@ -23,63 +23,32 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 
 class BindUtils
 {
-    private static bool $configured = false;
-    private static string $cacheNamespace = 'bind_view';
-    private static int $cacheLifetime = 0;
-    private static string $version = '';
-    private static ?string $warmCachePath = null;
+    private const int CACHE_LIFETIME_SECONDS = 86400; // 24 hours
     private const int MAX_CACHE_SIZE = 1024;
 
+    private string $cacheNamespace;
+    private int $cacheLifetime;
+    private string $version;
+    private ?string $warmCachePath;
+
     /** @var array<string, array<string, array{0: \ReflectionProperty, 1: \ReflectionProperty}>> */
-    private static array $storage = [];
+    private array $storage = [];
 
     /** @var array<string, array<string, array{0: array{class: class-string, name: string}, 1: array{class: class-string, name: string}}>>|null */
-    private static ?array $warmedCache = null;
+    private ?array $warmedCache = null;
     private ReflectionService $reflectionService;
+    private ?ReflectionPropertyAccessor $accessor = null;
 
-    private function __construct()
-    {
+    public function __construct(
+        string $buildId = '',
+        bool $debug = false,
+        ?string $shareDir = null,
+    ) {
+        $this->version = $buildId;
+        $this->cacheLifetime = $debug ? 0 : self::CACHE_LIFETIME_SECONDS;
+        $this->cacheNamespace = 'view_bind';
+        $this->warmCachePath = $shareDir ? $shareDir."/bind_utils_mappings_{$buildId}.php" : null;
         $this->reflectionService = new ReflectionService();
-    }
-
-    /**
-     * Configures caching parameters. Called once at bootstrap via SetVersionSubscriber.
-     * Subsequent calls are ignored to ensure configuration consistency.
-     *
-     * @param string      $buildId       Unique build identifier for cache versioning (e.g., container.build_id)
-     * @param int         $cacheLifetime Cache lifetime in seconds (0 = disabled, used in debug mode)
-     * @param string      $namespace     Cache namespace prefix to prevent collisions
-     * @param string|null $shareDir      Optional share directory for loading warmed cache
-     *
-     * @throws \InvalidArgumentException If cacheLifetime is negative or namespace is empty
-     */
-    public static function configure(string $buildId, int $cacheLifetime = 3600, string $namespace = 'bind_view', ?string $shareDir = null): void
-    {
-        if (self::$configured) {
-            return;
-        }
-
-        if ($cacheLifetime < 0) {
-            throw new \InvalidArgumentException(\sprintf('Cache lifetime must be non-negative, got %d', $cacheLifetime));
-        }
-
-        if ('' === $namespace) {
-            throw new \InvalidArgumentException('Cache namespace cannot be empty');
-        }
-
-        self::$configured = true;
-        self::$version = $buildId;
-        self::$cacheLifetime = $cacheLifetime;
-        self::$cacheNamespace = $namespace;
-        self::$warmCachePath = $shareDir ? $shareDir."/bind_utils_mappings_{$buildId}.php" : null;
-    }
-
-    public static function instance(): self
-    {
-        /** @var self|null $instance */
-        static $instance;
-
-        return $instance ??= new self();
     }
 
     /**
@@ -111,6 +80,50 @@ class BindUtils
         }
     }
 
+    public static function isReflectionTypeValidForInitialization(\ReflectionType $targetType, \ReflectionType $sourceType): bool
+    {
+        if (!$targetType instanceof \ReflectionNamedType) {
+            // union types are not supported for binding
+            return false;
+        }
+
+        $sourceTypes = $sourceType instanceof \ReflectionUnionType ? $sourceType->getTypes() : [$sourceType];
+
+        if ($targetType->isBuiltin()) {
+            // pass all built in values, in case if one of the source values is built in either
+            foreach ($sourceTypes as $st) {
+                if ($st instanceof \ReflectionNamedType && $st->isBuiltin()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (self::isAutoConfigurableType($targetType)) {
+            return true;
+        }
+
+        foreach ($sourceTypes as $st) {
+            // all custom objects are valid only if the types are valid
+            if ($st instanceof \ReflectionNamedType && \is_a($targetType->getName(), $st->getName(), true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function isView(\ReflectionType $type): bool
+    {
+        return $type instanceof \ReflectionNamedType && \is_a($type->getName(), ViewInterface::class, true);
+    }
+
+    public static function isAutoConfigurableType(\ReflectionNamedType $type): bool
+    {
+        return \array_any([BindView::class, IterableView::class], fn ($class) => \is_a($type->getName(), $class, true));
+    }
+
     private function getValue(\ReflectionProperty $targetProperty, \ReflectionProperty $sourceProperty, object $source): mixed
     {
         if (null === $value = $this->getAccessor()->getValue($source, $sourceProperty->getName())) {
@@ -119,7 +132,7 @@ class BindUtils
 
         $type = $targetProperty->getType();
 
-        if (null !== $type && $this->isView($type)) {
+        if (null !== $type && self::isView($type)) {
             if (!$type instanceof \ReflectionNamedType) {
                 throw new \LogicException(\sprintf('Property %s::$%s has view type but is not a named type. Union/intersection types with ViewInterface are not supported.', $targetProperty->getDeclaringClass()->getName(), $targetProperty->getName()));
             }
@@ -169,17 +182,17 @@ class BindUtils
         $sourceClassName = ClassUtils::getClass($source);
         $cacheKey = $targetClassName.'@'.$sourceClassName;
 
-        // 1. Check runtime cache (existing)
-        if (isset(self::$storage[$cacheKey])) {
-            return self::$storage[$cacheKey];
+        // 1. Check runtime cache
+        if (isset($this->storage[$cacheKey])) {
+            return $this->storage[$cacheKey];
         }
 
-        // 2. Check warmed cache (NEW)
+        // 2. Check warmed cache
         if ($warmed = $this->loadFromWarmedCache($cacheKey)) {
-            return self::$storage[$cacheKey] = $warmed;
+            return $this->storage[$cacheKey] = $warmed;
         }
 
-        // 3. Fall back to reflection (existing)
+        // 3. Fall back to reflection
         $targetProperties = $this->reflectionService->getReflectionProperties($targetClassName);
         $sourceProperties = $this->reflectionService->getReflectionProperties($sourceClassName);
 
@@ -196,18 +209,18 @@ class BindUtils
                 continue;
             }
 
-            if (!$this->isReflectionTypeValidForInitialization($targetType, $sourceType)) {
+            if (!self::isReflectionTypeValidForInitialization($targetType, $sourceType)) {
                 continue;
             }
 
             $intersection[$propertyName] = [$targetProperty, $sourceProperty];
         }
 
-        if (\count(self::$storage) >= self::MAX_CACHE_SIZE) {
-            unset(self::$storage[\array_key_first(self::$storage)]);
+        if (\count($this->storage) >= self::MAX_CACHE_SIZE) {
+            unset($this->storage[\array_key_first($this->storage)]);
         }
 
-        return self::$storage[$cacheKey] = $intersection;
+        return $this->storage[$cacheKey] = $intersection;
     }
 
     /**
@@ -217,22 +230,22 @@ class BindUtils
      */
     private function loadFromWarmedCache(string $cacheKey): ?array
     {
-        if (null === self::$warmCachePath || !\file_exists(self::$warmCachePath)) {
+        if (null === $this->warmCachePath || !\file_exists($this->warmCachePath)) {
             return null;
         }
 
         // Load warmed cache file once
-        if (null === self::$warmedCache) {
+        if (null === $this->warmedCache) {
             /** @var array<string, array<string, array{0: array{class: class-string, name: string}, 1: array{class: class-string, name: string}}>> $loaded */
-            $loaded = require self::$warmCachePath;
-            self::$warmedCache = $loaded;
+            $loaded = require $this->warmCachePath;
+            $this->warmedCache = $loaded;
         }
 
-        if (!isset(self::$warmedCache[$cacheKey])) {
+        if (!isset($this->warmedCache[$cacheKey])) {
             return null;
         }
 
-        $cached = self::$warmedCache[$cacheKey];
+        $cached = $this->warmedCache[$cacheKey];
         $result = [];
 
         // Reconstruct ReflectionProperty objects from cached data
@@ -251,57 +264,10 @@ class BindUtils
         return $result;
     }
 
-    private function isReflectionTypeValidForInitialization(\ReflectionType $targetType, \ReflectionType $sourceType): bool
-    {
-        if (!$targetType instanceof \ReflectionNamedType) {
-            // union types are not supported for binding
-            return false;
-        }
-
-        $sourceTypes = $sourceType instanceof \ReflectionUnionType ? $sourceType->getTypes() : [$sourceType];
-
-        if ($targetType->isBuiltin()) {
-            // pass all built in values, in case if one of the source values is built in either
-            foreach ($sourceTypes as $st) {
-                if ($st instanceof \ReflectionNamedType && $st->isBuiltin()) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        if ($this->isAutoConfigurableType($targetType)) {
-            return true;
-        }
-
-        foreach ($sourceTypes as $st) {
-            // all custom objects are valid only if the types are valid
-            if ($st instanceof \ReflectionNamedType && \is_a($targetType->getName(), $st->getName(), true)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isView(\ReflectionType $type): bool
-    {
-        return $type instanceof \ReflectionNamedType && \is_a($type->getName(), ViewInterface::class, true);
-    }
-
-    private function isAutoConfigurableType(\ReflectionNamedType $type): bool
-    {
-        return \array_any([BindView::class, IterableView::class], fn ($class) => \is_a($type->getName(), $class, true));
-    }
-
     private function getAccessor(): ReflectionPropertyAccessor
     {
-        /** @var ReflectionPropertyAccessor|null $accessor */
-        static $accessor;
-
-        if (null !== $accessor) {
-            return $accessor;
+        if (null !== $this->accessor) {
+            return $this->accessor;
         }
 
         $accessorPrefixes = ['get', 'is', 'has'];
@@ -327,8 +293,8 @@ class BindUtils
             ReflectionExtractor::DISALLOW_MAGIC_METHODS
         );
 
-        $cache = self::$configured
-            ? PropertyAccessor::createCache(self::$cacheNamespace, self::$cacheLifetime, self::$version)
+        $cache = '' !== $this->version
+            ? PropertyAccessor::createCache($this->cacheNamespace, $this->cacheLifetime, $this->version)
             : null;
 
         $propertyAccessor = new PropertyAccessor(
@@ -339,6 +305,6 @@ class BindUtils
             $writeExtractor
         );
 
-        return $accessor = new ReflectionPropertyAccessor($propertyAccessor, $this->reflectionService);
+        return $this->accessor = new ReflectionPropertyAccessor($propertyAccessor, $this->reflectionService);
     }
 }

--- a/src/Utils/BindUtils.php
+++ b/src/Utils/BindUtils.php
@@ -121,7 +121,7 @@ class BindUtils
 
     public static function isAutoConfigurableType(\ReflectionNamedType $type): bool
     {
-        return \array_any([BindView::class, IterableView::class], fn ($class) => \is_a($type->getName(), $class, true));
+        return \array_any([BindView::class, IterableView::class], static fn ($class) => \is_a($type->getName(), $class, true));
     }
 
     private function getValue(\ReflectionProperty $targetProperty, \ReflectionProperty $sourceProperty, object $source): mixed
@@ -168,7 +168,7 @@ class BindUtils
         /** @var Type $type */
         $type = $attr->newInstance();
 
-        return new IterableView($value, fn (object|array $v) => new ($type->class)($v));
+        return new IterableView($value, static fn (object|array $v) => new ($type->class)($v));
     }
 
     /**

--- a/src/View/BindView.php
+++ b/src/View/BindView.php
@@ -15,8 +15,20 @@ use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 
 abstract class BindView extends \stdClass implements ViewInterface
 {
+    private static ?BindUtils $bindUtils = null;
+
+    public static function setBindUtils(?BindUtils $bindUtils): void
+    {
+        self::$bindUtils = $bindUtils;
+    }
+
     public function __construct(object $object)
     {
-        BindUtils::instance()->sync($this, $object);
+        self::getBindUtils()->sync($this, $object);
+    }
+
+    private static function getBindUtils(): BindUtils
+    {
+        return self::$bindUtils ??= new BindUtils();
     }
 }

--- a/src/View/IterableView.php
+++ b/src/View/IterableView.php
@@ -42,7 +42,7 @@ class IterableView extends View implements NormalizableInterface
      */
     protected static function map(array|object $value): ViewInterface
     {
-        $valueType = \is_object($value) ? \get_class($value) : \gettype($value);
+        $valueType = \is_object($value) ? $value::class : \gettype($value);
         throw new \RuntimeException(\sprintf('%s should be defined or mapping closure should be passed for value of type %s', __METHOD__, $valueType));
     }
 

--- a/tests/Integrational/CacheWarmer/CacheLoadingTest.php
+++ b/tests/Integrational/CacheWarmer/CacheLoadingTest.php
@@ -27,32 +27,17 @@ final class CacheLoadingTest extends TestCase
     {
         $this->cacheDir = \sys_get_temp_dir().'/view_bundle_integration_'.\uniqid();
         \mkdir($this->cacheDir, 0777, true);
-
-        // Reset BindUtils static state
-        $reflection = new \ReflectionClass(BindUtils::class);
-        $configured = $reflection->getProperty('configured');
-        $configured->setValue(null, false);
-        $storage = $reflection->getProperty('storage');
-        $storage->setValue(null, []);
-        $warmedCache = $reflection->getProperty('warmedCache');
-        $warmedCache->setValue(null, null);
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
+        BindView::setBindUtils(null);
+
         if (\is_dir($this->cacheDir)) {
             \array_map('unlink', \glob($this->cacheDir.'/*'));
             \rmdir($this->cacheDir);
         }
-
-        // Reset BindUtils
-        $reflection = new \ReflectionClass(BindUtils::class);
-        $configured = $reflection->getProperty('configured');
-        $configured->setValue(null, false);
-        $storage = $reflection->getProperty('storage');
-        $storage->setValue(null, []);
-        $warmedCache = $reflection->getProperty('warmedCache');
-        $warmedCache->setValue(null, null);
     }
 
     public function testViewMetadataFactoryLoadsFromWarmedCache(): void
@@ -121,20 +106,21 @@ final class CacheLoadingTest extends TestCase
         self::assertArrayHasKey('name', $cached[$key]);
         self::assertArrayHasKey('id', $cached[$key]);
 
-        // Configure BindUtils with matching build ID and share dir
-        BindUtils::configure('test-build-id', 0, 'test', $this->cacheDir);
+        // Create BindUtils with matching build ID and share dir
+        $bindUtils = new BindUtils('test-build-id', false, $this->cacheDir);
+        BindView::setBindUtils($bindUtils);
 
-        // Verify warmed cache path includes build ID
+        // Verify warmed cache path includes build ID via reflection
         $reflection = new \ReflectionClass(BindUtils::class);
         $warmPathProp = $reflection->getProperty('warmCachePath');
-        $warmCachePath = $warmPathProp->getValue();
+        $warmCachePath = $warmPathProp->getValue($bindUtils);
         self::assertSame($this->cacheDir.'/bind_utils_mappings_test-build-id.php', $warmCachePath);
     }
 
     public function testBindUtilsFallsBackToReflectionWhenCacheMissing(): void
     {
-        // Configure BindUtils with empty cache dir (no warmed cache)
-        BindUtils::configure('test-build-id', 0, 'test', $this->cacheDir);
+        // Create BindUtils with empty cache dir (no warmed cache)
+        $bindUtils = new BindUtils('test-build-id', false, $this->cacheDir);
 
         // Verify no cache file exists
         self::assertFileDoesNotExist($this->cacheDir.'/bind_utils_mappings_test-build-id.php');
@@ -149,7 +135,7 @@ final class CacheLoadingTest extends TestCase
         };
 
         // Sync using BindUtils - should use reflection fallback
-        BindUtils::instance()->sync($target, $source);
+        $bindUtils->sync($target, $source);
 
         self::assertSame('test', $target->value);
     }
@@ -165,8 +151,9 @@ final class CacheLoadingTest extends TestCase
         $warmer = new BindUtilsCacheWarmer([$viewClass::class], '', 'test-build-id');
         $warmer->warmUp($this->cacheDir);
 
-        // Configure BindUtils with matching build ID
-        BindUtils::configure('test-build-id', 0, 'test', $this->cacheDir);
+        // Create BindUtils with matching build ID
+        $bindUtils = new BindUtils('test-build-id', false, $this->cacheDir);
+        BindView::setBindUtils($bindUtils);
 
         // Trigger cache loading by using BindUtils
         $source1 = new class {
@@ -175,12 +162,12 @@ final class CacheLoadingTest extends TestCase
         $target1 = new class {
             public ?string $shared = null;  // Nullable with null value
         };
-        BindUtils::instance()->sync($target1, $source1);
+        $bindUtils->sync($target1, $source1);
 
-        // Verify cache was loaded into static property
+        // Verify cache was loaded into instance property
         $reflection = new \ReflectionClass(BindUtils::class);
         $warmedCacheProp = $reflection->getProperty('warmedCache');
-        $warmedCache = $warmedCacheProp->getValue();
+        $warmedCache = $warmedCacheProp->getValue($bindUtils);
         self::assertNotNull($warmedCache, 'Warmed cache should be loaded');
 
         // Delete cache file
@@ -193,7 +180,7 @@ final class CacheLoadingTest extends TestCase
         $target2 = new class {
             public ?string $shared = null;  // Nullable with null value
         };
-        BindUtils::instance()->sync($target2, $source2);
+        $bindUtils->sync($target2, $source2);
 
         self::assertSame('second', $target2->shared);
     }
@@ -210,7 +197,6 @@ final class CacheLoadingTest extends TestCase
         };
 
         $buildId = 'abc123';
-        $viewClasses = [$testView::class, $bindView::class];
 
         // Warm metadata cache
         $metadataWarmer = new ViewMetadataCacheWarmer(new ViewMetadataFactory(), [$testView::class], '', $buildId);
@@ -275,9 +261,9 @@ final class CacheLoadingTest extends TestCase
         self::assertSame($testView::class, $metadataB->className);
 
         // Verify BindUtils with build A reads build A's file
-        BindUtils::configure($buildIdA, 0, 'test', $this->cacheDir);
+        $bindUtils = new BindUtils($buildIdA, false, $this->cacheDir);
         $reflection = new \ReflectionClass(BindUtils::class);
         $warmPathProp = $reflection->getProperty('warmCachePath');
-        self::assertSame($this->cacheDir."/bind_utils_mappings_{$buildIdA}.php", $warmPathProp->getValue());
+        self::assertSame($this->cacheDir."/bind_utils_mappings_{$buildIdA}.php", $warmPathProp->getValue($bindUtils));
     }
 }

--- a/tests/Integrational/CacheWarmer/CacheLoadingTest.php
+++ b/tests/Integrational/CacheWarmer/CacheLoadingTest.php
@@ -26,7 +26,7 @@ final class CacheLoadingTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = \sys_get_temp_dir().'/view_bundle_integration_'.\uniqid();
-        \mkdir($this->cacheDir, 0777, true);
+        \mkdir($this->cacheDir, 0o777, true);
         BindView::setBindUtils(null);
     }
 
@@ -62,7 +62,7 @@ final class CacheLoadingTest extends TestCase
         self::assertSame($testView::class, $metadata->className);
         self::assertCount(2, $metadata->properties);
 
-        $propNames = \array_map(fn ($p) => $p->name, $metadata->properties);
+        $propNames = \array_map(static fn ($p) => $p->name, $metadata->properties);
         self::assertContains('name', $propNames);
         self::assertContains('count', $propNames);
     }

--- a/tests/Integrational/EventSubscriber/SetVersionSubscriberTest.php
+++ b/tests/Integrational/EventSubscriber/SetVersionSubscriberTest.php
@@ -12,58 +12,40 @@ declare(strict_types=1);
 namespace Tests\Integrational\EventSubscriber;
 
 use ChamberOrchestra\ViewBundle\EventSubscriber\SetVersionSubscriber;
-use ChamberOrchestra\ViewBundle\PropertyAccessor\ReflectionService;
-use ChamberOrchestra\ViewBundle\Utils\BindUtils;
+use ChamberOrchestra\ViewBundle\View\BindView;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class SetVersionSubscriberTest extends KernelTestCase
 {
     protected function setUp(): void
     {
-        $this->resetBindUtils();
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
-        $this->resetBindUtils();
+        BindView::setBindUtils(null);
         static::ensureKernelShutdown();
     }
 
-    public function testSubscriberConfiguresBindUtilsWithContainerBuildId(): void
+    public function testSubscriberConfiguresBindViewWithBindUtils(): void
     {
-        $kernel = static::bootKernel();
+        static::bootKernel();
         $container = static::getContainer();
 
         /** @var SetVersionSubscriber $subscriber */
         $subscriber = $container->get(SetVersionSubscriber::class);
-
         $subscriber();
 
-        $buildId = $container->getParameter('container.build_id');
+        // Verify BindView works after subscriber invocation
+        $source = new class {
+            public string $name = 'integration-test';
+        };
 
-        self::assertSame($buildId, $this->getBindUtilsProperty('version'));
-        self::assertSame($container->getParameter('kernel.debug') ? 0 : 24 * 3600, $this->getBindUtilsProperty('cacheLifetime'));
-        self::assertSame('view_bind', $this->getBindUtilsProperty('cacheNamespace'));
-        self::assertTrue($this->getBindUtilsProperty('configured'));
-    }
+        $view = new class($source) extends BindView {
+            public string $name;
+        };
 
-    private function getBindUtilsProperty(string $property): mixed
-    {
-        return new \ReflectionProperty(BindUtils::class, $property)->getValue();
-    }
-
-    private function resetBindUtils(): void
-    {
-        foreach ([
-            'configured' => false,
-            'cacheNamespace' => 'bind_view',
-            'cacheLifetime' => 0,
-            'version' => '',
-            'storage' => [],
-        ] as $property => $value) {
-            new \ReflectionProperty(BindUtils::class, $property)->setValue(null, $value);
-        }
-
-        new \ReflectionProperty(ReflectionService::class, 'storage')->setValue(null, []);
+        self::assertSame('integration-test', $view->name);
     }
 }

--- a/tests/Integrational/View/BindViewTest.php
+++ b/tests/Integrational/View/BindViewTest.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Tests\Integrational\View;
 
-use ChamberOrchestra\ViewBundle\PropertyAccessor\ReflectionService;
-use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use ChamberOrchestra\ViewBundle\View\BindView;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -22,12 +20,12 @@ final class BindViewTest extends KernelTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
         static::ensureKernelShutdown();
     }
 
@@ -48,20 +46,5 @@ final class BindViewTest extends KernelTestCase
         $result = $serializer->normalize($view, 'json');
 
         self::assertSame(['title' => 'hello', 'count' => 3], $result);
-    }
-
-    private function resetStaticState(): void
-    {
-        foreach ([
-            'configured' => false,
-            'cacheNamespace' => 'bind_view',
-            'cacheLifetime' => 0,
-            'version' => '',
-            'storage' => [],
-        ] as $prop => $value) {
-            new \ReflectionProperty(BindUtils::class, $prop)->setValue(null, $value);
-        }
-
-        new \ReflectionProperty(ReflectionService::class, 'storage')->setValue(null, []);
     }
 }

--- a/tests/Unit/Attribute/BindsFromTest.php
+++ b/tests/Unit/Attribute/BindsFromTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the ChamberOrchestra package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\Attribute;
+
+use ChamberOrchestra\ViewBundle\Attribute\BindsFrom;
+use PHPUnit\Framework\TestCase;
+
+final class BindsFromTest extends TestCase
+{
+    public function testItStoresClassCorrectly(): void
+    {
+        $attr = new BindsFrom(\stdClass::class);
+
+        self::assertSame(\stdClass::class, $attr->class);
+    }
+
+    public function testItRejectsNonExistentClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Class "NonExistent\Foo\Bar" does not exist');
+
+        new BindsFrom('NonExistent\\Foo\\Bar');
+    }
+
+    public function testItTargetsClassAndIsRepeatable(): void
+    {
+        $reflection = new \ReflectionClass(BindsFrom::class);
+        $attributes = $reflection->getAttributes(\Attribute::class);
+
+        self::assertCount(1, $attributes);
+
+        /** @var \Attribute $attr */
+        $attr = $attributes[0]->newInstance();
+
+        self::assertNotSame(0, $attr->flags & \Attribute::TARGET_CLASS);
+        self::assertNotSame(0, $attr->flags & \Attribute::IS_REPEATABLE);
+    }
+
+    public function testItWorksAsRepeatableAttributeOnClass(): void
+    {
+        $reflection = new \ReflectionClass(BindsFromFixtureView::class);
+        $attributes = $reflection->getAttributes(BindsFrom::class);
+
+        self::assertCount(2, $attributes);
+        self::assertSame(BindsFromFixtureEntityA::class, $attributes[0]->newInstance()->class);
+        self::assertSame(BindsFromFixtureEntityB::class, $attributes[1]->newInstance()->class);
+    }
+}
+
+class BindsFromFixtureEntityA
+{
+}
+
+class BindsFromFixtureEntityB
+{
+}
+
+#[BindsFrom(BindsFromFixtureEntityA::class)]
+#[BindsFrom(BindsFromFixtureEntityB::class)]
+class BindsFromFixtureView
+{
+}

--- a/tests/Unit/CacheWarmer/BindUtilsCacheWarmerTest.php
+++ b/tests/Unit/CacheWarmer/BindUtilsCacheWarmerTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\CacheWarmer;
 
+use ChamberOrchestra\ViewBundle\Attribute\BindsFrom;
 use ChamberOrchestra\ViewBundle\CacheWarmer\BindUtilsCacheWarmer;
 use ChamberOrchestra\ViewBundle\View\BindView;
 use PHPUnit\Framework\TestCase;
@@ -23,10 +24,13 @@ final class BindUtilsCacheWarmerTest extends TestCase
     {
         $this->cacheDir = \sys_get_temp_dir().'/view_bundle_test_'.\uniqid();
         \mkdir($this->cacheDir, 0777, true);
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
+        BindView::setBindUtils(null);
+
         if (\is_dir($this->cacheDir)) {
             \array_map('unlink', \glob($this->cacheDir.'/*'));
             \rmdir($this->cacheDir);
@@ -136,5 +140,70 @@ final class BindUtilsCacheWarmerTest extends TestCase
                 self::assertArrayHasKey($key, $cached, "Missing mapping for $key");
             }
         }
+    }
+
+    public function testWarmUpUsesBindsFromAttributeWhenPresent(): void
+    {
+        $viewClasses = [CacheWarmerAnnotatedView::class, CacheWarmerUnannotatedView::class];
+        $warmer = new BindUtilsCacheWarmer($viewClasses, '', 'test-build');
+
+        $files = $warmer->warmUp($this->cacheDir);
+        $cached = require $files[0];
+
+        // Annotated view should only have mapping from declared source
+        $annotatedFromSource = CacheWarmerAnnotatedView::class.'@'.CacheWarmerSourceEntity::class;
+        self::assertArrayHasKey($annotatedFromSource, $cached);
+
+        // Annotated view should NOT have mapping from unannotated view (not in BindsFrom)
+        $annotatedFromUnannotated = CacheWarmerAnnotatedView::class.'@'.CacheWarmerUnannotatedView::class;
+        self::assertArrayNotHasKey($annotatedFromUnannotated, $cached);
+    }
+
+    public function testMixedAnnotatedAndUnannotatedViews(): void
+    {
+        $viewClasses = [CacheWarmerAnnotatedView::class, CacheWarmerUnannotatedView::class];
+        $warmer = new BindUtilsCacheWarmer($viewClasses, '', 'test-build');
+
+        $files = $warmer->warmUp($this->cacheDir);
+        $cached = require $files[0];
+
+        // Unannotated view should have mappings from ALL view classes (N² fallback)
+        $unannotatedFromAnnotated = CacheWarmerUnannotatedView::class.'@'.CacheWarmerAnnotatedView::class;
+        $unannotatedFromUnannotated = CacheWarmerUnannotatedView::class.'@'.CacheWarmerUnannotatedView::class;
+        self::assertArrayHasKey($unannotatedFromAnnotated, $cached);
+        self::assertArrayHasKey($unannotatedFromUnannotated, $cached);
+
+        // Annotated view should only map from its declared source
+        $annotatedFromSource = CacheWarmerAnnotatedView::class.'@'.CacheWarmerSourceEntity::class;
+        self::assertArrayHasKey($annotatedFromSource, $cached);
+
+        // Count: annotated=1 (from source entity) + unannotated=2 (from all views)
+        self::assertCount(3, $cached);
+    }
+}
+
+class CacheWarmerSourceEntity
+{
+    public string $name = '';
+}
+
+#[BindsFrom(CacheWarmerSourceEntity::class)]
+class CacheWarmerAnnotatedView extends BindView
+{
+    public string $name = '';
+
+    public function __construct(object $object)
+    {
+        parent::__construct($object);
+    }
+}
+
+class CacheWarmerUnannotatedView extends BindView
+{
+    public string $name = '';
+
+    public function __construct(object $object)
+    {
+        parent::__construct($object);
     }
 }

--- a/tests/Unit/CacheWarmer/BindUtilsCacheWarmerTest.php
+++ b/tests/Unit/CacheWarmer/BindUtilsCacheWarmerTest.php
@@ -23,7 +23,7 @@ final class BindUtilsCacheWarmerTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = \sys_get_temp_dir().'/view_bundle_test_'.\uniqid();
-        \mkdir($this->cacheDir, 0777, true);
+        \mkdir($this->cacheDir, 0o777, true);
         BindView::setBindUtils(null);
     }
 

--- a/tests/Unit/CacheWarmer/ViewMetadataCacheWarmerTest.php
+++ b/tests/Unit/CacheWarmer/ViewMetadataCacheWarmerTest.php
@@ -23,7 +23,7 @@ final class ViewMetadataCacheWarmerTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheDir = \sys_get_temp_dir().'/view_bundle_test_'.\uniqid();
-        \mkdir($this->cacheDir, 0777, true);
+        \mkdir($this->cacheDir, 0o777, true);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/DependencyInjection/ChamberOrchestraViewExtensionTest.php
+++ b/tests/Unit/DependencyInjection/ChamberOrchestraViewExtensionTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Tests\Unit\DependencyInjection;
 
 use ChamberOrchestra\ViewBundle\DependencyInjection\ChamberOrchestraViewExtension;
-use ChamberOrchestra\ViewBundle\EventSubscriber\SetVersionSubscriber;
+use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -25,7 +25,7 @@ final class ChamberOrchestraViewExtensionTest extends TestCase
         $extension = new ChamberOrchestraViewExtension();
         $extension->load([], $container);
 
-        $definition = $container->getDefinition(SetVersionSubscriber::class);
+        $definition = $container->getDefinition(BindUtils::class);
         $argument = $definition->getArgument('$buildId');
 
         $this->assertInstanceOf(Parameter::class, $argument);

--- a/tests/Unit/EventSubscriber/SetVersionSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/SetVersionSubscriberTest.php
@@ -13,58 +13,45 @@ namespace Tests\Unit\EventSubscriber;
 
 use ChamberOrchestra\ViewBundle\EventSubscriber\SetVersionSubscriber;
 use ChamberOrchestra\ViewBundle\Utils\BindUtils;
+use ChamberOrchestra\ViewBundle\View\BindView;
 use PHPUnit\Framework\TestCase;
 
 final class SetVersionSubscriberTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->resetBindUtils();
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
-        $this->resetBindUtils();
+        BindView::setBindUtils(null);
     }
 
-    public function testItConfiguresBindUtilsWithCacheWhenNotInDebug(): void
+    public function testItSetsBindUtilsOnBindView(): void
     {
-        $subscriber = new SetVersionSubscriber('build-123', false);
+        $bindUtils = new BindUtils('build-123');
+        $subscriber = new SetVersionSubscriber($bindUtils);
         $subscriber();
 
-        $this->assertSame('build-123', $this->getBindUtilsProperty('version'));
-        $this->assertSame(24 * 3600, $this->getBindUtilsProperty('cacheLifetime'));
-        $this->assertSame('view_bind', $this->getBindUtilsProperty('cacheNamespace'));
-        $this->assertTrue($this->getBindUtilsProperty('configured'));
+        // Verify BindView received the BindUtils instance by using it
+        $source = new class {
+            public string $name = 'test';
+        };
+
+        $view = new class($source) extends BindView {
+            public string $name;
+        };
+
+        self::assertSame('test', $view->name);
     }
 
-    public function testItDisablesCacheWhenDebugIsEnabled(): void
+    public function testItAcceptsBindUtilsViaConstructor(): void
     {
-        $subscriber = new SetVersionSubscriber('debug-build', true);
-        $subscriber();
+        $bindUtils = new BindUtils('build-456', true, '/tmp/share');
+        $subscriber = new SetVersionSubscriber($bindUtils);
 
-        $this->assertSame('debug-build', $this->getBindUtilsProperty('version'));
-        $this->assertSame(0, $this->getBindUtilsProperty('cacheLifetime'));
-        $this->assertSame('view_bind', $this->getBindUtilsProperty('cacheNamespace'));
-        $this->assertTrue($this->getBindUtilsProperty('configured'));
-    }
-
-    private function getBindUtilsProperty(string $property): mixed
-    {
-        return new \ReflectionProperty(BindUtils::class, $property)->getValue();
-    }
-
-    private function resetBindUtils(): void
-    {
-        foreach ([
-            'configured' => false,
-            'cacheNamespace' => 'bind_view',
-            'cacheLifetime' => 0,
-            'version' => '',
-            'storage' => [],
-        ] as $property => $value) {
-            $ref = new \ReflectionProperty(BindUtils::class, $property);
-            $ref->setValue(null, $value);
-        }
+        // Just verifying construction works — no exception thrown
+        self::assertInstanceOf(SetVersionSubscriber::class, $subscriber);
     }
 }

--- a/tests/Unit/EventSubscriber/ViewSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/ViewSubscriberTest.php
@@ -52,7 +52,7 @@ final class ViewSubscriberTest extends TestCase
             ->expects(self::once())
             ->method('serialize')
             ->with(
-                self::callback(fn ($value) => $value instanceof DataView && $value->data === $view),
+                self::callback(static fn ($value) => $value instanceof DataView && $value->data === $view),
                 'json',
                 ['json_encode_options' => \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT]
             )

--- a/tests/Unit/PropertyAccessor/ReflectionServiceTest.php
+++ b/tests/Unit/PropertyAccessor/ReflectionServiceTest.php
@@ -16,11 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 final class ReflectionServiceTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $this->resetCache();
-    }
-
     public function testItCachesAndMergesParentProperties(): void
     {
         $service = new ReflectionService();
@@ -66,12 +61,6 @@ final class ReflectionServiceTest extends TestCase
 
         $this->assertArrayHasKey('childProp', $properties);
         $this->assertArrayHasKey('parentProp', $properties);
-    }
-
-    private function resetCache(): void
-    {
-        $ref = new \ReflectionProperty(ReflectionService::class, 'storage');
-        $ref->setValue(null, []);
     }
 }
 

--- a/tests/Unit/Serializer/Normalizer/ViewNormalizerTest.php
+++ b/tests/Unit/Serializer/Normalizer/ViewNormalizerTest.php
@@ -49,7 +49,7 @@ final class ViewNormalizerTest extends TestCase
         $inner
             ->expects(self::exactly(2))
             ->method('normalize')
-            ->willReturnCallback(function (mixed $value, ?string $format, array $context) use ($view) {
+            ->willReturnCallback(static function (mixed $value, ?string $format, array $context) use ($view) {
                 self::assertSame('json', $format);
                 self::assertSame(['k' => 'v'], $context);
 

--- a/tests/Unit/Utils/BindUtilsTest.php
+++ b/tests/Unit/Utils/BindUtilsTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Tests\Unit\Utils;
 
 use ChamberOrchestra\ViewBundle\Attribute\Type;
-use ChamberOrchestra\ViewBundle\PropertyAccessor\ReflectionService;
 use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use ChamberOrchestra\ViewBundle\View\BindView;
 use ChamberOrchestra\ViewBundle\View\IterableView;
@@ -22,27 +21,35 @@ final class BindUtilsTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
     }
 
-    public function testConfigureRunsOnlyOnce(): void
+    public function testConstructorAcceptsConfigParameters(): void
     {
-        BindUtils::configure('first', 123, 'ns_first');
-        BindUtils::configure('second', 999, 'ns_second');
+        $bindUtils = new BindUtils('build-123', true, '/tmp/share');
 
-        self::assertSame('first', $this->getBindUtilsProperty('version'));
-        self::assertSame(123, $this->getBindUtilsProperty('cacheLifetime'));
-        self::assertSame('ns_first', $this->getBindUtilsProperty('cacheNamespace'));
-        self::assertTrue($this->getBindUtilsProperty('configured'));
+        // Verify the instance was created successfully by using it
+        $source = new class {
+            public string $name = 'test';
+        };
+        $target = new class {
+            public ?string $name = null;
+        };
+
+        $bindUtils->sync($target, $source);
+
+        self::assertSame('test', $target->name);
     }
 
     public function testSyncCopiesMissingValuesAndLeavesExistingOnes(): void
     {
+        $bindUtils = new BindUtils();
+
         $source = new class {
             public string $name = 'Alice';
             public int $age = 30;
@@ -53,17 +60,17 @@ final class BindUtilsTest extends TestCase
             public int $age = 5;
         };
 
-        BindUtils::instance()->sync($target, $source);
+        $bindUtils->sync($target, $source);
 
         self::assertSame('Alice', $target->name);
         self::assertSame(5, $target->age, 'Existing non-null value must not be overridden');
-
-        $storage = $this->getBindUtilsProperty('storage');
-        self::assertCount(1, $storage, 'Intersection cache should contain computed mapping');
     }
 
     public function testSyncMapsViewAndIterableViewProperties(): void
     {
+        $bindUtils = new BindUtils();
+        BindView::setBindUtils($bindUtils);
+
         $child = new class {
             public string $id = 'child-id';
         };
@@ -85,7 +92,7 @@ final class BindUtilsTest extends TestCase
             public IterableView $children;
         };
 
-        BindUtils::instance()->sync($target, $source);
+        $bindUtils->sync($target, $source);
 
         self::assertInstanceOf(ChildView::class, $target->child);
         self::assertSame($child, $target->child->source);
@@ -98,6 +105,8 @@ final class BindUtilsTest extends TestCase
 
     public function testSyncSkipsIncompatibleOrUnsupportedTypes(): void
     {
+        $bindUtils = new BindUtils();
+
         $source = new class {
             public object $incompatible;
             public string $union = 'value';
@@ -113,7 +122,7 @@ final class BindUtilsTest extends TestCase
             public int|string|null $union = null;
         };
 
-        BindUtils::instance()->sync($target, $source);
+        $bindUtils->sync($target, $source);
 
         self::assertNull($target->incompatible);
         self::assertNull($target->union);
@@ -121,6 +130,9 @@ final class BindUtilsTest extends TestCase
 
     public function testSyncAllowsAutoConfigurableTargetTypes(): void
     {
+        $bindUtils = new BindUtils();
+        BindView::setBindUtils($bindUtils);
+
         $child = new class {
             public string $id = 'child-id';
         };
@@ -138,30 +150,10 @@ final class BindUtilsTest extends TestCase
             public ?ChildView $child = null;
         };
 
-        BindUtils::instance()->sync($target, $source);
+        $bindUtils->sync($target, $source);
 
         self::assertInstanceOf(ChildView::class, $target->child);
         self::assertSame($child, $target->child->source);
-    }
-
-    private function getBindUtilsProperty(string $property): mixed
-    {
-        return new \ReflectionProperty(BindUtils::class, $property)->getValue();
-    }
-
-    private function resetStaticState(): void
-    {
-        foreach ([
-            'configured' => false,
-            'cacheNamespace' => 'bind_view',
-            'cacheLifetime' => 0,
-            'version' => '',
-            'storage' => [],
-        ] as $prop => $value) {
-            new \ReflectionProperty(BindUtils::class, $prop)->setValue(null, $value);
-        }
-
-        new \ReflectionProperty(ReflectionService::class, 'storage')->setValue(null, []);
     }
 }
 

--- a/tests/Unit/View/BindViewTest.php
+++ b/tests/Unit/View/BindViewTest.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\View;
 
-use ChamberOrchestra\ViewBundle\PropertyAccessor\ReflectionService;
-use ChamberOrchestra\ViewBundle\Utils\BindUtils;
 use ChamberOrchestra\ViewBundle\View\BindView;
 use PHPUnit\Framework\TestCase;
 
@@ -20,12 +18,12 @@ final class BindViewTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
     }
 
     protected function tearDown(): void
     {
-        $this->resetStaticState();
+        BindView::setBindUtils(null);
     }
 
     public function testItMapsPropertiesFromSource(): void
@@ -42,20 +40,5 @@ final class BindViewTest extends TestCase
 
         self::assertSame('orchestra', $view->name);
         self::assertSame(5, $view->count);
-    }
-
-    private function resetStaticState(): void
-    {
-        foreach ([
-            'configured' => false,
-            'cacheNamespace' => 'bind_view',
-            'cacheLifetime' => 0,
-            'version' => '',
-            'storage' => [],
-        ] as $prop => $value) {
-            new \ReflectionProperty(BindUtils::class, $prop)->setValue(null, $value);
-        }
-
-        new \ReflectionProperty(ReflectionService::class, 'storage')->setValue(null, []);
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `#[BindsFrom]` attribute for BindView subclasses to declare source classes, enabling targeted cache warming instead of N² pairs
- Convert `BindUtils` from singleton with static state to a proper DI service with instance properties and public constructor
- Add `BindView::setBindUtils()` static bridge for DI integration with fallback to standalone usage
- Simplify `SetVersionSubscriber` to inject `BindUtils` directly
- Deduplicate type validation by extracting shared static methods from `BindUtils`, fixing missing `isAutoConfigurableType()` check in cache warmer
- Convert `ReflectionService` from static to instance storage
- Remove all reflection-based test state resets

## Test plan

- [x] All 93 unit + integration tests pass (`composer test`)
- [x] PHPStan static analysis passes (`composer analyse`)
- [x] Code style check passes (`composer cs-check`)
- [x] All 10 benchmark subjects run without error (`composer bench`)

🤖 Generated with [Claude Code](https://claude.ai/code)